### PR TITLE
Function in udf_stats to calc p-value for controlled experiments

### DIFF
--- a/lib/udf_stats.rb
+++ b/lib/udf_stats.rb
@@ -1,0 +1,30 @@
+class UdfStats
+    UDFS = [
+        {
+          type:        :function,
+          name:        :experiment_result_p_value,
+          description: "Returns a p-value for a controlled experiment to determine statistical significance",
+          params:      "control_size float, control_conversion float, experiment_size float, experiment_conversion float",
+          return_type: "float",
+          body:        %~
+            from scipy.stats import chi2_contingency
+            from numpy import array
+            observed = array([
+              [control_size - control_conversion, control_conversion],
+              [experiment_size - experiment_conversion, experiment_conversion]
+            ])
+            result = chi2_contingency(observed, correction=True)
+            chisq, p = result[:2]
+            return p
+
+          ~,
+          tests: [
+            {query: "select round(?(5000,486, 5000, 527),3)", expect: 0.185, example: true},
+            {query: "select case when ?(5000,486, 5000, 527) < 0.05 then 'yes' else 'no' end as signifcant", expect: 'no', example: true},
+            {query: "select ?(20000,17998,20000, 17742)", expect: 3.57722238820663e-05, example: true},
+            {query: "select case when ?(20000,17998,20000, 17742) < 0.05 then 'yes' else 'no' end as significant", expect: 'yes', example: true}
+          ]
+        }
+    ]
+
+end

--- a/udf_harness.rb
+++ b/udf_harness.rb
@@ -15,6 +15,7 @@ class UdfHarness
         UdfTimeHelpers::UDFS,
         UdfStringUtils::UDFS,
         UdfNumberUtils::UDFS,
+        UdfStats::UDFS,
     ].flatten.select { |u| only_udf.nil? or u[:name] == only_udf.to_sym }
   end
 


### PR DESCRIPTION
Hey there! 
I just wanted to add a useful little UDF to calculate p-values for experiments (such as the results of an A/B test). I added a new udf_stats.rb file with the idea that you could add other useful stats utils from scipy/numpy, such as t-tests, etc later on.

I hope I went about this the right way, please let me know if I can change or cleanup anything!
