### PR TITLE
Add function to remove accents from string

### DIFF
--- a/lib/udf_string_utils.rb
+++ b/lib/udf_string_utils.rb
@@ -231,6 +231,24 @@ class UdfStringUtils
                            {query: "select ?('', '')", expect: nil},
                            {query: "select ?(null, null)", expect: nil},
                        ]
+      }, {
+          type:        :function,
+          name:        :remove_accents,
+          description: "Remove accents from a string",
+          params:      "str varchar(max)",
+          return_type: "varchar(max)",
+          body:        %~
+            import unicodedata
+            if not str:
+              return None
+            str = str.decode('utf-8')
+            return unicodedata.normalize('NFKD', str).encode('ASCII', 'ignore')
+          ~,
+          tests:       [
+                           {query: "select ?('café')", expect: 'cafe', example: true},
+                           {query: "select ?('')", expect: nil},
+                           {query: "select ?(null)", expect: nil},
+                       ]
       }
     ]
 end

--- a/udfs.sql
+++ b/udfs.sql
@@ -623,3 +623,20 @@
           chisq, p = result[:2]
           return p
         $$ language plpythonu;
+
+      /*
+      REMOVE_ACCENTS
+      Remove accents from a string
+
+      Examples:
+        select remove_accents('café') --> 'cafe'
+      */
+      create or replace function remove_accents (str varchar(max))
+        returns varchar(max)
+        stable as $$
+          import unicodedata
+          if not str:
+            return None
+          str = str.decode('utf-8')
+          return unicodedata.normalize('NFKD', str).encode('ASCII', 'ignore')
+        $$ language plpythonu;


### PR DESCRIPTION
Add `remove_accents` UDF to remove accent marks and accented characters from a string.

Examples:
```sql
select remove_accents('café') --> 'cafe'
select remove_accents('naïve'); --> 'naive'
select remove_accents('Conceição'); --> 'Conceicao'
```