### PR TITLE
Long json strings

### DIFF
--- a/lib/udf_ip_utils.rb
+++ b/lib/udf_ip_utils.rb
@@ -1,0 +1,50 @@
+class UdfIpUtils
+  UDFS = [
+      {
+          type:        :function,
+          name:        :ip_to_int,
+          description: "Transform string readable IP address to its int value",
+          params:      "ip_address varchar(max)",
+          return_type: "bigint",
+          body:        %~
+
+            import struct
+            import socket
+            try:
+                res = struct.unpack("!I", socket.inet_aton(ip_address))[0]
+            except:
+                res = 0
+            return res
+
+          ~,
+          tests: [
+              {query: "select ?('192.168.1.1')", expect: '3232235777', example: true},
+              {query: "select ?('0.0.0.0')", expect: '0', example: true},
+              {query: "select ?('a')", expect: '0'},
+              {query: "select ?('')", expect: '0'},
+          ]
+      },
+      {
+          type:        :function,
+          name:        :int_to_ip,
+          description: "Transform integer IP address to its string readable format",
+          params:      "ip_int bigint",
+          return_type: "varchar(max)",
+          body:        %~
+
+            import struct
+            import socket
+            try:
+                res =  socket.inet_ntoa(struct.pack("!I", ip_int))
+            except:
+                res = 0
+            return res
+
+          ~,
+          tests: [
+              {query: "select ?(3232235777)", expect: '192.168.1.1', example: true},
+              {query: "select ?(0)", expect: '0.0.0.0', example: true},
+          ]
+      }
+  ]
+end

--- a/lib/udf_json_dicts.rb
+++ b/lib/udf_json_dicts.rb
@@ -4,8 +4,8 @@ class UdfJsonDicts
           type:        :function,
           name:        :json_extract_path_keys,
           description: "Return the list of keys in a json dict as a json string",
-          params:      "jsonstr varchar(max)",
-          return_type: "varchar(max)",
+          params:      "jsonstr varchar(10000)",
+          return_type: "varchar(10000)",
           body:        %~
             import json
             if not jsonstr:
@@ -22,8 +22,8 @@ class UdfJsonDicts
           type:        :function,
           name:        :json_extract_path_key,
           description: "Return a specific key of a json dict",
-          params:      "jsonstr varchar(max), pos integer, reverse boolean",
-          return_type: "varchar(max)",
+          params:      "jsonstr varchar(10000), pos integer, reverse boolean",
+          return_type: "varchar(10000)",
           body:        %~
             import json
             if not jsonstr:

--- a/lib/udf_json_dicts.rb
+++ b/lib/udf_json_dicts.rb
@@ -1,0 +1,46 @@
+class UdfJsonDicts
+  UDFS = [
+      {
+          type:        :function,
+          name:        :json_extract_path_keys,
+          description: "Return the list of keys in a json dict as a json string",
+          params:      "jsonstr varchar(max)",
+          return_type: "varchar(max)",
+          body:        %~
+            import json
+            if not jsonstr:
+              return '[]'
+            else:
+              return json.dumps(sorted(json.loads(str(jsonstr)).keys()))
+          ~,
+          tests:       [
+                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}')", expect: '["a", "b"]', example: true},
+                           {query: "select ?('{\"a\": \"A\"}')", expect: '["a"]', example: true},
+                           {query: "select ?('{}')", expect: '[]', example: true}
+                       ]
+      }, {
+          type:        :function,
+          name:        :json_extract_path_key,
+          description: "Return a specific key of a json dict",
+          params:      "jsonstr varchar(max), pos integer, reverse boolean",
+          return_type: "varchar(max)",
+          body:        %~
+            import json
+            if not jsonstr:
+              return ''
+            else:
+              keys = sorted(json.loads(str(jsonstr)).keys(), reverse=reverse)
+              if len(keys) <= pos:
+                return ''
+              else:
+                return keys[pos]
+          ~,
+          tests:       [
+                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 0)", expect: 'a', example: true},
+                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 0, True)", expect: 'b', example: true},
+                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 1)", expect: 'b', example: true},
+                           {query: "select ?('{\"a\": \"A\", \"b\": \"B\"}', 1, True)", expect: 'a', example: true}
+                       ]
+      }
+  ]
+end

--- a/lib/udf_stats.rb
+++ b/lib/udf_stats.rb
@@ -27,12 +27,17 @@ class UdfStats
         }, {
             type:        :function,
             name:        :binomial_hpdr,
-            description: "Returns true if a value is within the Highest Posterior Density Region",
-            params:      "value float, successes integer, samples integer, pct float, a integer, b integer, n_pbins integer",
-            return_type: "integer",
+            description: "Compare value against boundaries of Highest Posterior Density Region",
+            params:      "value float, successes bigint, samples bigint, pct float, a bigint, b bigint, n_pbins integer",
+            return_type: "smallint",
             body:        %~
               # Taken from:
               # http://stackoverflow.com/a/19285227
+
+              # Check input arguments
+              if successes is None or samples is None or samples < 1:
+                return None
+
               import numpy
               from scipy.stats import beta
               from scipy.stats import norm
@@ -50,11 +55,11 @@ class UdfStats
                 min_p = 1.
               p_range = numpy.linspace(min_p, max_p, n_pbins+1)
               if mode > 0.5:
-                  sf = rv.sf(p_range)
-                  pmf = sf[:-1] - sf[1:]
+                sf = rv.sf(p_range)
+                pmf = sf[:-1] - sf[1:]
               else:
-                  cdf = rv.cdf(p_range)
-                  pmf = cdf[1:] - cdf[:-1]
+                cdf = rv.cdf(p_range)
+                pmf = cdf[1:] - cdf[:-1]
               # find the upper and lower bounds of the interval 
               sorted_idxs = numpy.argsort( pmf )[::-1]
               cumsum = numpy.cumsum( numpy.sort(pmf)[::-1] )
@@ -79,11 +84,16 @@ class UdfStats
             type:        :function,
             name:        :binomial_hpdr_upper,
             description: "Returns the upper boundary fo the Highest Posterior Density Region",
-            params:      "successes integer, samples integer, pct float, a integer, b integer, n_pbins integer",
+            params:      "successes bigint, samples bigint, pct float, a bigint, b bigint, n_pbins integer",
             return_type: "float",
             body:        %~
               # Taken from:
               # http://stackoverflow.com/a/19285227
+
+              # Check input arguments
+              if successes is None or samples is None or samples < 1:
+                return None
+
               import numpy
               from scipy.stats import beta
               from scipy.stats import norm
@@ -121,11 +131,16 @@ class UdfStats
             type:        :function,
             name:        :binomial_hpdr_lower,
             description: "Returns the lower boundary of the Highest Posterior Density Region",
-            params:      "successes integer, samples integer, pct float, a integer, b integer, n_pbins integer",
+            params:      "successes bigint, samples bigint, pct float, a bigint, b bigint, n_pbins integer",
             return_type: "float",
             body:        %~
               # Taken from:
               # http://stackoverflow.com/a/19285227
+
+              # Check input arguments
+              if successes is None or samples is None or samples < 1:
+                return None
+
               import numpy
               from scipy.stats import beta
               from scipy.stats import norm

--- a/lib/udf_string_utils.rb
+++ b/lib/udf_string_utils.rb
@@ -231,6 +231,19 @@ class UdfStringUtils
                            {query: "select ?('', '')", expect: nil},
                            {query: "select ?(null, null)", expect: nil},
                        ]
+      }, {
+          type:        :function,
+          name:        :str_join_range,
+          description: "Joins a numeric range with a given separator",
+          params:      "first integer, last integer, step integer, delimiter varchar(max)",
+          return_type: "varchar(max)",
+          body:        %~
+            return delimiter.join(str(x) for x in range(first, last, step))
+          ~,
+          tests:       [
+                           {query: "select ?(1, 3, 1, ',')", expect: "1,2" , example: true},
+                           {query: "select ?(1, 5, 2, '|')", expect: "1|3", example: true},
+                       ]
       }
     ]
 end

--- a/udf_harness.rb
+++ b/udf_harness.rb
@@ -16,6 +16,7 @@ class UdfHarness
         UdfStringUtils::UDFS,
         UdfNumberUtils::UDFS,
         UdfStats::UDFS,
+        UdfIpUtils::UDFS,
     ].flatten.select { |u| only_udf.nil? or u[:name] == only_udf.to_sym }
   end
 

--- a/udf_harness.rb
+++ b/udf_harness.rb
@@ -10,6 +10,7 @@ class UdfHarness
   def initialize(only_udf = nil)
     @udfs = [
         UdfJsonArrays::UDFS,
+        UdfJsonDicts::UDFS,
         UdfMysqlCompat::UDFS,
         UdfTimeHelpers::UDFS,
         UdfStringUtils::UDFS,


### PR DESCRIPTION
Apparently `varchar(max)` means `varchar(256)` for Redshift:

https://forums.aws.amazon.com/message.jspa?messageID=685756

That is too short for some of the experiments dicts we get from the NFH and caused the corresponding ETL step to fail. I have already loaded this modified version of the UDFs in Redshift and rerun the failed ETL job.